### PR TITLE
Make Digest::SHA1 threadsafe

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,4 +1,4 @@
-require 5.004;
+require 5.008;
 use ExtUtils::MakeMaker;
 
 WriteMakefile(

--- a/README
+++ b/README
@@ -5,7 +5,7 @@ input a message of arbitrary length and produces as output a 160-bit
 
 SHA1 is described at <http://www.itl.nist.gov/fipspubs/fip180-1.htm>
 
-You will need Perl version 5.004 or better to install this module.
+You will need Perl version 5.8 or better to install this module.
 
 Copyright 1999-2004 Gisle Aas.
 Copyright 1997 Uwe Hollerbach.

--- a/t/threads.t
+++ b/t/threads.t
@@ -1,0 +1,26 @@
+use strict;
+use warnings;
+use Test::More;
+use Config;
+
+BEGIN {
+    plan skip_all => 'Perl compiled without ithreads'
+        unless $Config{useithreads};
+    plan tests => 2;
+}
+
+use threads;
+use Digest::SHA1;
+
+my $obj = Digest::SHA1->new;
+$obj->add("foo");
+my $tdigest = threads->create(sub {
+    $obj->add("bar");
+    $obj->hexdigest;
+})->join;
+
+isnt $obj->clone->hexdigest, $tdigest,
+    "unshared object unaffected by the thread";
+
+$obj->add("bar");
+is $obj->clone->hexdigest, $tdigest;


### PR DESCRIPTION
These changes make the module safe to use in threads. They are almost exactly the same as the prior Digest::MD5 changes, but include the dependency on perl 5.8 and the subsequent cleanup.
