### PR TITLE
Support padded base64 digests

### DIFF
--- a/SHA1.pm
+++ b/SHA1.pm
@@ -7,7 +7,7 @@ $VERSION = '2.13';
 
 require Exporter;
 *import = \&Exporter::import;
-@EXPORT_OK = qw(sha1 sha1_hex sha1_base64 sha1_transform);
+@EXPORT_OK = qw(sha1 sha1_hex sha1_base64 sha1_base64_padded sha1_transform);
 
 require DynaLoader;
 @ISA=qw(DynaLoader);

--- a/SHA1.xs
+++ b/SHA1.xs
@@ -423,6 +423,7 @@ static char* base64_20(const unsigned char* from, char* to)
 #define F_BIN 0
 #define F_HEX 1
 #define F_B64 2
+#define F_B64_PAD 3
 
 static SV* make_mortal_sv(pTHX_ const unsigned char *src, int type)
 {
@@ -442,6 +443,12 @@ static SV* make_mortal_sv(pTHX_ const unsigned char *src, int type)
     case F_B64:
 	ret = base64_20(src, result);
 	len = 27;
+	break;
+    case F_B64_PAD:
+	ret = base64_20(src, result);
+	ret[27] = '=';
+	ret[28] = '\0';
+	len = 28;
 	break;
     default:
 	croak("Bad convertion type (%d)", type);
@@ -545,6 +552,7 @@ digest(context)
 	Digest::SHA1::digest    = F_BIN
 	Digest::SHA1::hexdigest = F_HEX
 	Digest::SHA1::b64digest = F_B64
+	Digest::SHA1::b64digest_padded = F_B64_PAD
     PREINIT:
 	unsigned char digeststr[20];
     PPCODE:
@@ -559,6 +567,7 @@ sha1(...)
 	Digest::SHA1::sha1        = F_BIN
 	Digest::SHA1::sha1_hex    = F_HEX
 	Digest::SHA1::sha1_base64 = F_B64
+	Digest::SHA1::sha1_base64_padded = F_B64_PAD
     PREINIT:
 	SHA_INFO ctx;
 	int i;
@@ -587,7 +596,8 @@ sha1(...)
 	    }
 	    if (msg) {
 		const char *f = (ix == F_BIN) ? "sha1" :
-                                (ix == F_HEX) ? "sha1_hex" : "sha1_base64";
+                                (ix == F_HEX) ? "sha1_hex" :
+                                (ix == F_B64) ? "sha1_base64" : "sha1_base64_padded";
 	        warn("&Digest::SHA1::%s function %s", f, msg);
 	    }
 	}

--- a/t/sha1.t
+++ b/t/sha1.t
@@ -1,6 +1,6 @@
-print "1..13\n";
+print "1..15\n";
 
-use Digest::SHA1 qw(sha1 sha1_hex sha1_base64 sha1_transform);
+use Digest::SHA1 qw(sha1 sha1_hex sha1_base64 sha1_base64_padded sha1_transform);
 
 print "not " unless Digest::SHA1->new->add("abc")->hexdigest eq "a9993e364706816aba3e25717850c26c9cd0d89d";
 print "ok 1\n";
@@ -14,6 +14,9 @@ print "ok 3\n";
 print "not " unless sha1_base64("abc") eq "qZk+NkcGgWq6PiVxeFDCbJzQ2J0";
 print "ok 4\n";
 
+print "not " unless sha1_base64_padded("abc") eq "qZk+NkcGgWq6PiVxeFDCbJzQ2J0=";
+print "ok 5\n";
+
 # Test file checking from too...
 open(FILE, ">stest$$.txt") || die;
 binmode(FILE);
@@ -25,7 +28,12 @@ close(FILE);
 open(FILE, "stest$$.txt") || die;
 $digest = Digest::SHA1->new->addfile(*FILE)->b64digest;
 print "$digest\nnot " unless $digest eq "1ZuIK/sQeBwqh+dIACqpnoRQUE4";
-print "ok 5\n";
+print "ok 6\n";
+
+seek(FILE, 0, 0);
+$digest = Digest::SHA1->new->addfile(*FILE)->b64digest_padded;
+print "$digest\nnot " unless $digest eq "1ZuIK/sQeBwqh+dIACqpnoRQUE4=";
+print "ok 7\n";
 close(FILE);
 
 unlink("stest$$.txt");
@@ -33,30 +41,30 @@ unlink("stest$$.txt");
 
 print "not " unless sha1_transform(pack('H*', 'dc71a8092d4b1b7b98101d58698d9d1cc48225bb')) 
 	eq pack('H*', '2e4c75ad39160f52614d122e6c7ec80446f68567');
-print "ok 6\n";
+print "ok 8\n";
 
 print "not " unless sha1_transform(pack('H*', '0abe1db666612acdf95d2f86d60c65210b78ab23')) 
 	eq pack('H*', '7c1c2aabca822912f3016299b160035787477b48');
-print "ok 7\n";
+print "ok 9\n";
 
 print "not " unless sha1_transform(pack('H*', '86da486230e353e0ec5e9220876c687892c0266c')) 
 	eq pack('H*', '1da304aec652c21d4f54642434705c91aeaf9abe');
-print "ok 8\n";
+print "ok 10\n";
 
 $digest = Digest::SHA1->new;
 print "not " unless $digest->hexdigest eq "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-print "ok 9\n";
+print "ok 11\n";
 
 print "not " unless $digest->clone->hexdigest eq "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-print "ok 10\n";
+print "ok 12\n";
 
 $digest->add("abc");
 print "not " unless $digest->clone->hexdigest eq "a9993e364706816aba3e25717850c26c9cd0d89d";
-print "ok 11\n";
+print "ok 13\n";
 
 $digest->add("d");
 print "not " unless $digest->hexdigest eq "81fe8bfe87576c3ecb22426f8e57847382917acf";
-print "ok 12\n";
+print "ok 14\n";
 
 print "not " unless $digest->hexdigest eq "da39a3ee5e6b4b0d3255bfef95601890afd80709";
-print "ok 13\n";
+print "ok 15\n";


### PR DESCRIPTION
Code expecting pluggable digest functions benefits from being able to
get padded base64 without writing the simple but not packaged

```
$digest .= '=' while length($digest) % 4;
```
